### PR TITLE
doc : fix predicates's list appearance in English REST predicates

### DIFF
--- a/docs/pages/apis/rest.en.mdx
+++ b/docs/pages/apis/rest.en.mdx
@@ -92,24 +92,61 @@ GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
 This will return all characters with the name "Weasley".
 
 <details>
-  <summary>Expand to see all available filter predicates</summary>- `eq`: equals - `eq_any`: equals
-  any - `eq_all`: equals all - `not_eq`: not equal to - `not_eq_any`: not equal to any -
-  `not_eq_all`: not equal to all - `matches`: matches - `matches_any`: matches any - `matches_all`:
-  matches all - `does_not_match`: doesn't match - `does_not_match_any`: doesn't match any -
-  `does_not_match_all`: doesn't match all - `lt`: less than - `lt_any`: less than any - `lt_all`:
-  less than all - `lteq`: less than or equal to - `lteq_any`: less than or equal to any -
-  `lteq_all`: less than or equal to all - `gt`: greater than - `gt_any`: greater than any -
-  `gt_all`: greater than all - `gteq`: greater than or equal to - `gteq_any`: greater than or equal
-  to any - `gteq_all`: greater than or equal to all - `in`: in - `in_any`: in any - `in_all`: in all
-  - `not_in`: not in - `not_in_any`: not in any - `not_in_all`: not in all - `cont`: contains -
-  `cont_any`: contains any - `cont_all`: contains all - `not_cont`: doesn't contain -
-  `not_cont_any`: doesn't contain any - `not_cont_all`: doesn't contain all - `start`: starts with -
-  `start_any`: starts with any - `start_all`: starts with all - `not_start`: doesn't start with -
-  `not_start_any`: doesn't start with any - `not_start_all`: doesn't start with all - `end`: ends
-  with - `end_any`: ends with any - `end_all`: ends with all - `not_end`: doesn't end with -
-  `not_end_any`: doesn't end with any - `not_end_all`: doesn't end with all - `'true'`: is true -
-  `'false'`: is false - `present`: is present - `blank`: is blank - `'null'`: is null - `not_null`:
-  is not null
+  <summary>Expand to see all available filter predicates</summary>
+  - `eq`: equals 
+  - `eq_any`: equals any 
+  - `eq_all`: equals all 
+  - `not_eq`: not equal to 
+  - `not_eq_any`: not equal to any 
+  - `not_eq_all`: not equal to all 
+  - `matches`: matches 
+  - `matches_any`: matches any 
+  - `matches_all`: matches all 
+  - `does_not_match`: doesn't match 
+  - `does_not_match_any`: doesn't match any 
+  - `does_not_match_all`: doesn't match all 
+  - `lt`: less than 
+  - `lt_any`: less than any 
+  - `lt_all`: less than all 
+  - `lteq`: less than or equal to 
+  - `lteq_any`: less than or equal to any 
+  - `lteq_all`: less than or equal to all 
+  - `gt`: greater than 
+  - `gt_any`: greater than any 
+  - `gt_all`: greater than all 
+  - `gteq`: greater than or equal to 
+  - `gteq_any`: greater than or equal to any 
+  - `gteq_all`: greater than or equal to all 
+  - `in`: in 
+  - `in_any`: in any 
+  - `in_all`: in all
+  - `not_in`: not in 
+  - `not_in_any`: not in any 
+  - `not_in_all`: not in all 
+  - `cont`: contains 
+  - `cont_any`: contains any 
+  - `cont_all`: contains all 
+  - `not_cont`: doesn't contain 
+  - `not_cont_any`: doesn't contain any 
+  - `not_cont_all`: doesn't contain all 
+  - `start`: starts with 
+  - `start_any`: starts with any 
+  - `start_all`: starts with all 
+  - `not_start`: doesn't start with 
+  - `not_start_any`: doesn't start with any 
+  - `not_start_all`: doesn't start with all 
+  - `end`: ends with 
+  - `end_any`: ends with any 
+  - `end_all`: ends with all 
+  - `not_end`: doesn't end with 
+  - `not_end_any`: doesn't end with any 
+  - `not_end_all`: doesn't end with all 
+  - `'true'`: is true 
+  - `'false'`: is false 
+  - `present`: is present 
+  - `blank`: is blank 
+  - `'null'`: is null 
+  - `not_null`: is not null
 </details>
 
 ### Sorting


### PR DESCRIPTION
Just a little fix of the appearance of the predicate's list as changed in the French translation's PR 's code review and as discussed in issue.

## Summary

Each predicate is now in one line

## Related Issues

Updates issue #738 

## Checklist

- [x] This pull request has a meaningful title and description.
- [x] I have read and followed the [Contributing guidelines](https://github.com/danielschuster-muc/potter-db/blob/master/CONTRIBUTING.md).
- [x] My code follows the conventions and coding style of this project.
- [x] All tests pass and I have added tests for my changes <!-- if applicable -->
- [x] I have updated necessary documentation <!-- if applicable -->

# Screenshots (if applicable)

![image](https://github.com/danielschuster-muc/potter-db/assets/82816247/fe8d5863-e5ef-426f-9657-1ab851286fde)


## Additional information

I don't think so
