### PR TITLE
Add spectral and rubocop linter

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -50,7 +50,7 @@ jobs:
           path: backend/coverage
 
   rubocop:
-    name: "RuboCop Lint"
+    name: "RuboCop Linter"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -60,11 +60,15 @@ jobs:
         with:
           bundler-cache: true
           working-directory: backend
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
       - name: Run RuboCop
         run: bundle exec rubocop
 
   spectral:
-    name: "Spectral Lint"
+    name: "Spectral Linter"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -75,3 +79,4 @@ jobs:
         uses: stoplightio/spectral-action@latest
         with:
           file_glob: "backend/app/documentation/v1/openapi.yaml"
+          spectral_ruleset: "backend/.spectral.yaml"

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -13,6 +13,7 @@ defaults:
     working-directory: backend
 jobs:
   test:
+    name: "RSpec Test"
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -33,21 +34,44 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # Add or replace dependency steps here
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@5cfe23c062c0aac352e765b1b7cc12ea5255ccc4 # v1.156.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           working-directory: backend
-      # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load
-      # Add or replace test runners here
       - name: Run tests
         run: bundler exec rspec
-      # Upload code coverage
       - name: Upload coverage results
         uses: actions/upload-artifact@master
         with:
           name: code-coverage
           path: backend/coverage
+
+  rubocop:
+    name: "RuboCop Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: backend
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+  spectral:
+    name: "Spectral Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral
+      - name: Run Spectral
+        uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: "backend/app/documentation/v1/openapi.yaml"

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -1,4 +1,10 @@
-require: rubocop-rspec
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-factory_bot
+  - rubocop-performance
+  # Re-add when improving graphql api
+  # - rubocop-graphql
 
 AllCops:
   NewCops: enable
@@ -40,4 +46,6 @@ Style/EmptyMethod:
 Bundler/OrderedGems:
   Enabled: false
 RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/EmptyExampleGroup:
   Enabled: false

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - "config/**/*"
     - "tmp/**/*"
     - "lib/**/*"
+    - "vendor/bundle/**/*"
 
 Style/ConditionalAssignment:
   Enabled: false

--- a/backend/.spectral.yaml
+++ b/backend/.spectral.yaml
@@ -1,0 +1,4 @@
+extends: [
+  "spectral:oas",
+  # "https://unpkg.com/@stoplight/spectral-owasp-ruleset/dist/ruleset.mjs"
+]

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -48,10 +48,10 @@ group :development, :test do
   gem "rspec-rails"
   # Seamlessly adds a Swagger to Rails-based API's [https://github.com/rswag/rswag]
   gem 'rswag-specs'
+  # Code coverage [https://github.com/simplecov-ruby/simplecov]
+  gem "simplecov"
   # Fixtures replacement [https://github.com/thoughtbot/factory_bot_rails]
   gem "factory_bot_rails"
-  # Code coverage [https://github.com/simplecov-ruby/simplecov]
-  gem "simplecov", require: false
 
   # Code analyzer and formatter [https://github.com/rubocop/rubocop]
   gem "rubocop"
@@ -59,6 +59,10 @@ group :development, :test do
   gem "rubocop-rails"
   # Code style checking for RSpec files [https://github.com/rubocop/rubocop-rspec]
   gem "rubocop-rspec"
+  # Rubocop extension for enforcing graphql-ruby best practices [https://github.com/DmitryTsepelev/rubocop-graphql]
+  gem 'rubocop-graphql'
+  # An extension of RuboCop focused on code performance checks [https://github.com/rubocop/rubocop-performance]
+  gem "rubocop-performance"
 end
 
 group :development do

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -235,6 +235,11 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.24.0)
       rubocop (~> 1.33)
+    rubocop-graphql (1.4.0)
+      rubocop (>= 0.90, < 2)
+    rubocop-performance (1.19.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rails (2.21.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -291,6 +296,8 @@ DEPENDENCIES
   rspec-rails
   rswag-specs
   rubocop
+  rubocop-graphql
+  rubocop-performance
   rubocop-rails
   rubocop-rspec
   simplecov

--- a/backend/README.md
+++ b/backend/README.md
@@ -63,7 +63,7 @@ Using [Bundler](https://github.com/bundler/bundler):
 bundle install
 ```
 
-Docker Installation 
+Docker Installation
 
 Run the following command in your terminal
 
@@ -81,7 +81,7 @@ Create and set up the database by running the following commands:
 rails db:create db:migrate
 rails db:seed
 ```
-Docker Installation 
+Docker Installation
 
 Open another terminal in backend folder and run
 
@@ -115,6 +115,14 @@ For any code changes, ensure that the backend tests are running successfully. Yo
 rspec spec
 ```
 
+### Rubocop Linting
+
+We use [Rubocop](https://github.com/rubocop/rubocop) to lint our code. To run the linter, use the following command:
+
+```shell
+bundle exec rubocop
+```
+
 ### OpenAPI Documentation
 
 Our API is documented using OpenAPI.
@@ -124,6 +132,12 @@ To update the documentation, make your changes in [rspec/request](spec/requests)
 rake rswag:specs:swaggerize
 ```
 You can now visit the documentation on http://localhost:3000/v1/openapi or in [app/documentation/v1/openapi.yml](app/documentation/v1/openapi.yml).
+
+To validate the documentation, run the following command:
+
+```shell
+spectral lint app/documentation/v1/openapi.yml
+```
 
 ### GraphQL Schema
 We also provide a GraphQL API. To update the GraphQL schema, make your changes in [app/graphql](app/graphql) and run the following command afterwards:

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::API
   def jsonapi_meta(resources)
     pagination = jsonapi_pagination_meta(resources)
     {
-      pagination: (pagination if pagination.present?),
-      copyright: "Copyright © Potter DB #{Date.today.year}",
+      pagination: pagination.presence,
+      copyright: "Copyright © Potter DB #{Time.zone.today.year}",
       generated_at: DateTime.now
     }.compact
   end

--- a/backend/app/controllers/graphql_controller.rb
+++ b/backend/app/controllers/graphql_controller.rb
@@ -23,6 +23,7 @@ class GraphqlController < ApplicationController
   private
 
   # Handle variables in form data, JSON body, or a blank value
+  # rubocop:disable Metrics/MethodLength
   def prepare_variables(variables_param)
     case variables_param
     when String
@@ -41,11 +42,13 @@ class GraphqlController < ApplicationController
       raise ArgumentError, "Unexpected parameter: #{variables_param}"
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def handle_error_in_development(error)
     logger.error error.message
     logger.error error.backtrace.join("\n")
 
-    render json: { errors: [{ status: 500, title: error.message, detail: error.backtrace }], data: {} }, status: 500
+    render json: { errors: [{ status: 500, title: error.message, detail: error.backtrace }], data: {} },
+           status: :internal_server_error
   end
 end

--- a/backend/app/controllers/v1/documentation_controller.rb
+++ b/backend/app/controllers/v1/documentation_controller.rb
@@ -3,7 +3,7 @@ module V1
     include ActionController::MimeResponds
 
     def openapi
-      yaml = File.read("#{Rails.root}/app/documentation/v1/openapi.yaml")
+      yaml = File.read(Rails.root.join("app/documentation/v1/openapi.yaml").to_s)
       respond_to do |format|
         format.yaml { render plain: yaml, content_type: 'text/yaml' }
         format.any { render json: YAML.load(yaml).to_json }

--- a/backend/app/controllers/v1/movies_controller.rb
+++ b/backend/app/controllers/v1/movies_controller.rb
@@ -1,8 +1,8 @@
 module V1
   class MoviesController < ApplicationController
     def index
-      allowed = %i[title summary directors screenwriters producers cinematographers editors music_composers release_date running_time budget
-                   box_office rating order]
+      allowed = %i[title summary directors screenwriters producers cinematographers editors music_composers release_date
+                   running_time budget box_office rating order]
 
       jsonapi_filter(Movie.all, allowed) do |filtered|
         jsonapi_paginate(filtered.result) do |paginated|

--- a/backend/app/documentation/v1/openapi.yaml
+++ b/backend/app/documentation/v1/openapi.yaml
@@ -78,7 +78,14 @@ paths:
       description: Retrieves a specific book by id, use "random" to get a random book.
       operationId: getBook
       parameters:
-      - "$ref": "#/components/parameters/book_id"
+      - name: id
+        description: The identifier of the book. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single book
@@ -108,7 +115,14 @@ paths:
         and filtered by attributes.
       operationId: getChapters
       parameters:
-      - "$ref": "#/components/parameters/book_id"
+      - name: id
+        description: The identifier of the book. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       - "$ref": "#/components/parameters/page_size"
       - "$ref": "#/components/parameters/page_number"
       - "$ref": "#/components/parameters/sort_chapters"
@@ -144,8 +158,23 @@ paths:
         to get a random chapter.
       operationId: getChapter
       parameters:
-      - "$ref": "#/components/parameters/book_chapter_id"
-      - "$ref": "#/components/parameters/chapter_id"
+      - name: book_id
+        description: The identifier of the book. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
+      - name: id
+        description: The identifier of the book's chapter. Must be a valid UUID v4
+          or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single chapter
@@ -204,7 +233,14 @@ paths:
         character.
       operationId: getCharacter
       parameters:
-      - "$ref": "#/components/parameters/character_id"
+      - name: id
+        description: The identifier of the character. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single character
@@ -262,7 +298,14 @@ paths:
         movie.
       operationId: getMovie
       parameters:
-      - "$ref": "#/components/parameters/movie_id"
+      - name: id
+        description: The identifier of the movie. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single movie
@@ -321,7 +364,14 @@ paths:
         potion.
       operationId: getPotion
       parameters:
-      - "$ref": "#/components/parameters/potion_id"
+      - name: id
+        description: The identifier of the potion. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single potion
@@ -379,7 +429,14 @@ paths:
         spell.
       operationId: getSpell
       parameters:
-      - "$ref": "#/components/parameters/spell_id"
+      - name: id
+        description: The identifier of the spell. Must be a valid UUID v4 or slug.
+        in: path
+        required: true
+        schema:
+          oneOf:
+          - "$ref": "#/components/schemas/uuid_path"
+          - "$ref": "#/components/schemas/slug_path"
       responses:
         '200':
           description: A single spell
@@ -404,7 +461,7 @@ components:
   parameters:
     page_size:
       name: page[size]
-      description: The number of returned results per page. (Between 1 and 100)
+      description: The number of returned results per page (between 1 and 100).
       in: query
       required: false
       schema:
@@ -421,70 +478,6 @@ components:
         type: integer
         minimum: 1
         default: 1
-    book_id:
-      name: id
-      description: The identifier of the book. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    book_chapter_id:
-      name: book_id
-      description: The identifier of the book. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    chapter_id:
-      name: id
-      description: The identifier of the book's chapter. Must be a valid UUID v4 or
-        slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    character_id:
-      name: id
-      description: The identifier of the character. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    movie_id:
-      name: id
-      description: The identifier of the movie. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    potion_id:
-      name: id
-      description: The identifier of the potion. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
-    spell_id:
-      name: id
-      description: The identifier of the spell. Must be a valid UUID v4 or slug.
-      in: path
-      required: true
-      schema:
-        oneOf:
-        - "$ref": "#/components/schemas/uuid_path"
-        - "$ref": "#/components/schemas/slug_path"
     sort_books:
       name: sort
       description: Sort books by the given field. If prefixed with "-" sort is descending.
@@ -766,7 +759,7 @@ components:
           format: date_time
       example:
         copyright: Copyright © Potter DB 2023
-        generated_at: '2023-10-13T01:58:07+02:00'
+        generated_at: '2023-10-14T21:53:54+02:00'
     pagination_links:
       type: object
       properties:

--- a/backend/app/documentation/v1/openapi.yaml
+++ b/backend/app/documentation/v1/openapi.yaml
@@ -78,13 +78,7 @@ paths:
       description: Retrieves a specific book by id, use "random" to get a random book.
       operationId: getBook
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the book. Must be a valid UUID v4 or
-          slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/book_id"
       responses:
         '200':
           description: A single book
@@ -110,19 +104,15 @@ paths:
       summary: Retrieves a list of chapters of a given book
       tags:
       - books
+      description: Retrieves a list of chapters of a given book; paginated, sorted
+        and filtered by attributes.
       operationId: getChapters
       parameters:
+      - "$ref": "#/components/parameters/book_id"
       - "$ref": "#/components/parameters/page_size"
       - "$ref": "#/components/parameters/page_number"
       - "$ref": "#/components/parameters/sort_chapters"
       - "$ref": "#/components/parameters/filter_chapters_by"
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the book. Must be a valid UUID v4 or
-          slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
       responses:
         '200':
           description: A list of chapters
@@ -154,20 +144,8 @@ paths:
         to get a random chapter.
       operationId: getChapter
       parameters:
-      - name: book_id
-        in: path
-        required: true
-        description: The unique identifier of the book. Must be a valid UUID v4 or
-          slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the chapter. Must be a valid UUID v4
-          or slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/book_chapter_id"
+      - "$ref": "#/components/parameters/chapter_id"
       responses:
         '200':
           description: A single chapter
@@ -224,15 +202,9 @@ paths:
       - characters
       description: Retrieves a specific character by id, use "random" to get a random
         character.
-      operationId: getcharacter
+      operationId: getCharacter
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the character. Must be a valid UUID
-          v4 or slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/character_id"
       responses:
         '200':
           description: A single character
@@ -288,15 +260,9 @@ paths:
       - movies
       description: Retrieves a specific movie by id, use "random" to get a random
         movie.
-      operationId: getmovie
+      operationId: getMovie
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the movie. Must be a valid UUID v4 or
-          slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/movie_id"
       responses:
         '200':
           description: A single movie
@@ -353,15 +319,9 @@ paths:
       - potions
       description: Retrieves a specific potion by id, use "random" to get a random
         potion.
-      operationId: getpotion
+      operationId: getPotion
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the potion. Must be a valid UUID v4
-          or slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/potion_id"
       responses:
         '200':
           description: A single potion
@@ -417,15 +377,9 @@ paths:
       - spells
       description: Retrieves a specific spell by id, use "random" to get a random
         spell.
-      operationId: getspell
+      operationId: getSpell
       parameters:
-      - name: id
-        in: path
-        required: true
-        description: The unique identifier of the spell. Must be a valid UUID v4 or
-          slug.
-        schema:
-          "$ref": "#components/schemas/id_path"
+      - "$ref": "#/components/parameters/spell_id"
       responses:
         '200':
           description: A single spell
@@ -467,6 +421,70 @@ components:
         type: integer
         minimum: 1
         default: 1
+    book_id:
+      name: id
+      description: The identifier of the book. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    book_chapter_id:
+      name: book_id
+      description: The identifier of the book. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    chapter_id:
+      name: id
+      description: The identifier of the book's chapter. Must be a valid UUID v4 or
+        slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    character_id:
+      name: id
+      description: The identifier of the character. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    movie_id:
+      name: id
+      description: The identifier of the movie. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    potion_id:
+      name: id
+      description: The identifier of the potion. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
+    spell_id:
+      name: id
+      description: The identifier of the spell. Must be a valid UUID v4 or slug.
+      in: path
+      required: true
+      schema:
+        oneOf:
+        - "$ref": "#/components/schemas/uuid_path"
+        - "$ref": "#/components/schemas/slug_path"
     sort_books:
       name: sort
       description: Sort books by the given field. If prefixed with "-" sort is descending.
@@ -737,49 +755,6 @@ components:
         type: object
         nullable: true
   schemas:
-    json_api_schema:
-      title: JSON:API Schema
-      description: This is a schema for reponses in the [JSON:API](https://jsonapi.org)
-        format.
-      oneOf:
-      - "$ref": "#/components/schemas/failure"
-      - "$ref": "#/components/schemas/info"
-      - "$ref": "#/components/schemas/success"
-    failure:
-      type: object
-      required:
-      - errors
-      properties:
-        errors:
-          type: array
-          items:
-            "$ref": "#/components/schemas/error"
-          uniqueItems: true
-      additionalProperties: false
-    info:
-      type: object
-      required:
-      - meta
-      properties:
-        meta:
-          "$ref": "#/components/schemas/meta"
-        links:
-          "$ref": "#/components/schemas/links"
-      additionalProperties: false
-    success:
-      type: object
-      required:
-      - data
-      properties:
-        data:
-          "$ref": "#/components/schemas/data"
-        meta:
-          "$ref": "#/components/schemas/meta"
-        links:
-          allOf:
-          - "$ref": "#/components/schemas/links"
-          - "$ref": "#/components/schemas/pagination_links"
-      additionalProperties: false
     meta:
       description: Meta information about the response.
       type: object
@@ -791,49 +766,7 @@ components:
           format: date_time
       example:
         copyright: Copyright © Potter DB 2023
-        generated_at: '2023-09-27T22:37:00+02:00'
-    data:
-      description: The primary data of the response.
-      oneOf:
-      - "$ref": "#/components/schemas/resource"
-      - type: array
-        description: An array of resources
-        items:
-          "$ref": "#/components/schemas/resource"
-        uniqueItems: true
-      - type: string
-        nullable: true
-    resource:
-      description: A resource that appears in a JSON:API response.
-      type: object
-      required:
-      - id
-      - type
-      properties:
-        type:
-          type: string
-        id:
-          type: string
-        attributes:
-          "$ref": "#/components/schemas/attributes"
-        relationships:
-          "$ref": "#/components/schemas/relationships"
-        links:
-          "$ref": "#/components/schemas/links"
-        meta:
-          "$ref": "#/components/schemas/meta"
-      additionalProperties: false
-    links:
-      type: array
-      description: Links to other resources.
-      items:
-        "$ref": "#/components/schemas/link"
-      uniqueItems: true
-    link:
-      description: A link to a resource
-      type: string
-      nullable: true
-      format: uriReference
+        generated_at: '2023-10-13T01:58:07+02:00'
     pagination_links:
       type: object
       properties:
@@ -863,90 +796,6 @@ components:
           nullable: true
       required:
       - self
-    attributes:
-      description: Attributes of a resource.
-      type: object
-      not:
-        anyOf:
-        - required:
-          - relationships
-        - required:
-          - links
-        - required:
-          - id
-        - required:
-          - type
-      additionalProperties: false
-    relationships:
-      description: Relationships of a resource.
-      type: object
-      properties:
-        resources:
-          description: The name of the relationship resource. See [Resource Object
-            Relationships](https://jsonapi.org/format/#document-resource-object-relationships)
-          type: object
-          properties:
-            data:
-              oneOf:
-              - "$ref": "#/components/schemas/relationship_to_one"
-              - "$ref": "#/components/schemas/relationship_to_many"
-      additionalProperties: false
-    relationship_to_one:
-      description: A relationship to a single resource.
-      anyOf:
-      - "$ref": "#/components/schemas/empty_relationship"
-      - "$ref": "#/components/schemas/linkage_relationship"
-    relationship_to_many:
-      description: A relationship to multiple resources.
-      type: array
-      items:
-        "$ref": "#/components/schemas/linkage_relationship"
-      uniqueItems: true
-    empty_relationship:
-      description: An empty relationship.
-      type: string
-      nullable: true
-    linkage_relationship:
-      description: A relationship to a resource.
-      type: object
-      required:
-      - id
-      - type
-      properties:
-        type:
-          type: string
-        id:
-          description: The unique identifier of the resource.
-          type: string
-          pattern: "^[a-zA-Z0-9](?:[-\\w]*[a-zA-Z0-9])?$"
-    error:
-      type: object
-      properties:
-        status:
-          description: The HTTP status code applicable to this problem, expressed
-            as a string value.
-          type: string
-        title:
-          description: A short, human-readable summary of the problem that SHOULD
-            NOT change from occurrence to occurrence of the problem, except for purposes
-            of localization.
-          type: string
-        detail:
-          description: A human-readable explanation specific to this occurrence of
-            the problem.
-          type: string
-        source:
-          type: object
-          properties:
-            pointer:
-              description: A JSON Pointer [RFC6901] to the associated entity in the
-                request document.
-              type: string
-            parameter:
-              description: A string indicating which URI query parameter caused the
-                error.
-              type: string
-      additionalProperties: false
     not_found:
       type: object
       properties:
@@ -966,25 +815,6 @@ components:
         errors:
         - title: Not found
           status: '404'
-    internal_server_error:
-      type: object
-      properties:
-        errors:
-          type: array
-          items:
-            type: object
-            properties:
-              status:
-                type: string
-                enum:
-                - '500'
-              title:
-                type: string
-                example: Internal Server Error
-      example:
-        errors:
-        - title: Internal server error
-          status: '500'
     success_without_data:
       type: object
       properties:
@@ -992,17 +822,21 @@ components:
           "$ref": "#/components/schemas/meta"
         links:
           "$ref": "#/components/schemas/pagination_links"
-    id_path:
+    uuid_path:
+      type: string
+      format: uuid
+      example: c1637a49-3cc8-4285-93a1-28e6579f1f20
+    slug_path:
       type: string
       pattern: "^[a-zA-Z0-9](?:[-\\w]*[a-zA-Z0-9])?$"
-      example: c1637a49-3cc8-4285-93a1-28e6579f1f20
+      example: harry-potter-and-the-philosopher-s-stone
     to_many_chapters_relationship:
       type: array
       uniqueItems: true
       items:
         "$ref": "#/components/schemas/to_one_chapter_relationship"
       example:
-        id: c1637a49-3cc8-4285-93a1-28e6579f1f20
+      - id: c1637a49-3cc8-4285-93a1-28e6579f1f20
         type: chapter
     to_one_chapter_relationship:
       type: object
@@ -1097,7 +931,7 @@ components:
           properties:
             self:
               type: string
-              format: uri
+              pattern: "/v1/books/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
               example: "/v1/books/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id
@@ -1149,8 +983,8 @@ components:
           properties:
             self:
               type: string
-              format: uri
-              example: v1/books/7f8d9b7c-5a7c-4f7c-9d5a-1d8e6f7a8b9d/chapters/c1637a49-3cc8-4285-93a1-28e6579f1f20
+              pattern: "/v1/books/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/chapters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+              example: "/v1/books/7f8d9b7c-5a7c-4f7c-9d5a-1d8e6f7a8b9d/chapters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id
       - type
@@ -1266,7 +1100,7 @@ components:
           properties:
             self:
               type: string
-              format: uri
+              pattern: "/v1/characters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
               example: "/v1/characters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id
@@ -1363,7 +1197,7 @@ components:
           properties:
             self:
               type: string
-              format: uri
+              pattern: "/v1/movies/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
               example: "/v1/movies/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id
@@ -1431,7 +1265,8 @@ components:
           properties:
             self:
               type: string
-              format: uri
+              pattern: "/v1/potions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+              example: "/v1/potions/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id
       - type
@@ -1493,7 +1328,7 @@ components:
           properties:
             self:
               type: string
-              format: uri
+              pattern: "/v1/spells/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
               example: "/v1/spells/c1637a49-3cc8-4285-93a1-28e6579f1f20"
       required:
       - id

--- a/backend/app/graphql/types/book_type.rb
+++ b/backend/app/graphql/types/book_type.rb
@@ -18,8 +18,8 @@ module Types
     end
 
     def chapter(chapter_slug:)
-      Book.find_by_slug(object.slug).chapters.all
-      Chapter.find_by_slug(chapter_slug)
+      Book.find_by(slug: object.slug).chapters.all
+      Chapter.find_by(slug: chapter_slug)
     end
   end
 end

--- a/backend/app/graphql/types/query_type.rb
+++ b/backend/app/graphql/types/query_type.rb
@@ -17,7 +17,7 @@ module Types
       argument :slug, String, required: true
     end
     def book(slug:)
-      Book.find_by_slug(slug)
+      Book.find_by(slug:)
     end
 
     # Characters
@@ -30,7 +30,7 @@ module Types
       argument :slug, String, required: true
     end
     def character(slug:)
-      Character.find_by_slug(slug)
+      Character.find_by(slug:)
     end
 
     # Movies
@@ -43,7 +43,7 @@ module Types
       argument :slug, String, required: true
     end
     def movie(slug:)
-      Movie.find_by_slug(slug)
+      Movie.find_by(slug:)
     end
 
     # Potions
@@ -56,7 +56,7 @@ module Types
       argument :slug, String, required: true
     end
     def potion(slug:)
-      Potion.find_by_slug(slug)
+      Potion.find_by(slug:)
     end
 
     # Spells
@@ -69,7 +69,7 @@ module Types
       argument :slug, String, required: true
     end
     def spell(slug:)
-      Spell.find_by_slug(slug)
+      Spell.find_by(slug:)
     end
   end
 end

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/backend/app/models/book.rb
+++ b/backend/app/models/book.rb
@@ -1,4 +1,4 @@
-class Book < ActiveRecord::Base
+class Book < ApplicationRecord
   has_many :chapters, dependent: :destroy
   default_scope { order(release_date: :asc) }
 

--- a/backend/app/models/chapter.rb
+++ b/backend/app/models/chapter.rb
@@ -1,4 +1,4 @@
-class Chapter < ActiveRecord::Base
+class Chapter < ApplicationRecord
   belongs_to :book
   default_scope { order(order: :asc) }
 

--- a/backend/app/models/character.rb
+++ b/backend/app/models/character.rb
@@ -1,31 +1,8 @@
-class Character < ActiveRecord::Base
+class Character < ApplicationRecord
   default_scope { order(name: :asc) }
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[
-      alias_names
-      animagus
-      blood_status
-      boggart
-      born
-      died
-      eye_color
-      family_members
-      gender
-      hair_color
-      height
-      house
-      jobs
-      marital_status
-      name
-      nationality
-      patronus
-      romances
-      skin_color
-      species
-      titles
-      wands
-      weight
-    ]
+    %w[alias_names animagus blood_status boggart born died eye_color family_members gender hair_color height house jobs
+       marital_status name nationality patronus romances skin_color species titles wands weight ]
   end
 end

--- a/backend/app/models/movie.rb
+++ b/backend/app/models/movie.rb
@@ -1,22 +1,8 @@
-class Movie < ActiveRecord::Base
+class Movie < ApplicationRecord
   default_scope { order(release_date: :asc) }
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[
-      box_office
-      budget
-      cinematographers
-      directors
-      distributors
-      editors
-      music_composers
-      producers
-      rating
-      release_date
-      running_time
-      screenwriters
-      summary
-      title
-    ]
+    %w[box_office budget cinematographers directors distributors editors music_composers producers rating release_date
+       running_time screenwriters summary title ]
   end
 end

--- a/backend/app/models/potion.rb
+++ b/backend/app/models/potion.rb
@@ -1,4 +1,4 @@
-class Potion < ActiveRecord::Base
+class Potion < ApplicationRecord
   default_scope { order(name: :asc) }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/backend/app/models/spell.rb
+++ b/backend/app/models/spell.rb
@@ -1,4 +1,4 @@
-class Spell < ActiveRecord::Base
+class Spell < ApplicationRecord
   default_scope { order(name: :asc) }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/backend/spec/config/initializers/rack_attack_spec.rb
+++ b/backend/spec/config/initializers/rack_attack_spec.rb
@@ -18,34 +18,36 @@ RSpec.describe "Rack::Attack", type: :request do
   end
 
   # TODO: fix this test, see: https://github.com/danielschuster-muc/potter-db/pull/733#discussion_r1339217847
-  xdescribe "GET /" do
+  describe "GET /", skip: "disabled as / redirects to docs.potterdb.com" do
     let(:limit) { 900 }
     let(:headers) { { "REMOTE_ADDR" => "1.2.3.4" } }
 
     context "when number of requests < limit" do
       it "does not change the request status" do
         limit.times do
-          get root_path, headers: headers
+          get(root_path, headers:)
           expect(response).not_to have_http_status(:too_many_requests)
         end
       end
     end
 
     context "when number of requests > limit" do
+      # rubocop:disable RSpec/ExampleLength
       it "changes the request status to 429" do
         freeze_time do
           (limit + 1).times do |i|
-            get root_path, headers: headers
+            get(root_path, headers:)
             expect(response).to have_http_status(:too_many_requests) if i > limit
           end
         end
 
         travel_to(1.hour.from_now) do
-          get root_path, headers: headers
+          get(root_path, headers:)
           expect(response).to have_http_status(:ok)
         end
       end
 
+      # rubocop:disable RSpec/NestedGroups
       context "when localhost" do
         skip("only run in test") unless Rails.env.test?
         let(:localhost_headers) { { "REMOTE_ADDR" => "127.0.0.1" } }
@@ -57,7 +59,9 @@ RSpec.describe "Rack::Attack", type: :request do
           end
         end
       end
+      # rubocop:enable RSpec/NestedGroups
 
+      # rubocop:disable RSpec/NestedGroups
       context "when potterdb.com" do
         let(:potterdb_headers) { { "REQUEST_URL" => "https://potterdb.com" } }
 
@@ -68,6 +72,8 @@ RSpec.describe "Rack::Attack", type: :request do
           end
         end
       end
+      # rubocop:enable RSpec/NestedGroups
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -36,7 +36,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join("spec/fixtures").to_s
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/backend/spec/requests/v1/books_spec.rb
+++ b/backend/spec/requests/v1/books_spec.rb
@@ -38,7 +38,16 @@ RSpec.describe 'V1::Books' do
       description 'Retrieves a specific book by id, use "random" to get a random book.'
       operationId 'getBook'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/book_id'
+      parameter name: 'id',
+                description: 'The identifier of the book. Must be a valid UUID v4 or slug.',
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single book' do
         schema allOf: [

--- a/backend/spec/requests/v1/books_spec.rb
+++ b/backend/spec/requests/v1/books_spec.rb
@@ -38,9 +38,7 @@ RSpec.describe 'V1::Books' do
       description 'Retrieves a specific book by id, use "random" to get a random book.'
       operationId 'getBook'
       produces 'application/vnd.api+json'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the book. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/book_id'
 
       response '200', 'A single book' do
         schema allOf: [

--- a/backend/spec/requests/v1/chapters_spec.rb
+++ b/backend/spec/requests/v1/chapters_spec.rb
@@ -4,15 +4,14 @@ RSpec.describe 'V1::Chapters' do
   path '/v1/books/{id}/chapters' do
     get 'Retrieves a list of chapters of a given book' do
       tags 'books'
+      description 'Retrieves a list of chapters of a given book; paginated, sorted and filtered by attributes.'
       operationId 'getChapters'
       produces 'application/vnd.api+json'
+      parameter '$ref': '#/components/parameters/book_id'
       parameter '$ref': '#/components/parameters/page_size'
       parameter '$ref': '#/components/parameters/page_number'
       parameter '$ref': '#/components/parameters/sort_chapters'
       parameter '$ref': '#/components/parameters/filter_chapters_by'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the book. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
 
       response '200', 'A list of chapters' do
         let(:id) { create(:book).id }
@@ -47,12 +46,8 @@ RSpec.describe 'V1::Chapters' do
       description 'Retrieves a specific chapter of a given book by id, use "random" to get a random chapter.'
       operationId 'getChapter'
       produces 'application/vnd.api+json'
-      parameter name: :book_id, in: :path, required: true,
-                description: "The unique identifier of the book. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the chapter. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/book_chapter_id'
+      parameter '$ref': '#/components/parameters/chapter_id'
 
       response '200', 'A single chapter' do
         let(:book) { create(:book) }

--- a/backend/spec/requests/v1/chapters_spec.rb
+++ b/backend/spec/requests/v1/chapters_spec.rb
@@ -7,7 +7,16 @@ RSpec.describe 'V1::Chapters' do
       description 'Retrieves a list of chapters of a given book; paginated, sorted and filtered by attributes.'
       operationId 'getChapters'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/book_id'
+      parameter name: 'id',
+                description: 'The identifier of the book. Must be a valid UUID v4 or slug.',
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
       parameter '$ref': '#/components/parameters/page_size'
       parameter '$ref': '#/components/parameters/page_number'
       parameter '$ref': '#/components/parameters/sort_chapters'
@@ -46,12 +55,30 @@ RSpec.describe 'V1::Chapters' do
       description 'Retrieves a specific chapter of a given book by id, use "random" to get a random chapter.'
       operationId 'getChapter'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/book_chapter_id'
-      parameter '$ref': '#/components/parameters/chapter_id'
+      parameter name: 'book_id',
+                description: "The identifier of the book. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
+      parameter name: 'id',
+                description: "The identifier of the book's chapter. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single chapter' do
         let(:book) { create(:book) }
-        let(:chapter) { create(:chapter, book: book) }
+        let(:chapter) { create(:chapter, book:) }
 
         let(:book_id) { book.id }
         let(:id) { chapter.id }

--- a/backend/spec/requests/v1/characters_spec.rb
+++ b/backend/spec/requests/v1/characters_spec.rb
@@ -38,7 +38,16 @@ RSpec.describe 'V1::Characters' do
       description 'Retrieves a specific character by id, use "random" to get a random character.'
       operationId 'getCharacter'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/character_id'
+      parameter name: 'id',
+                description: "The identifier of the character. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single character' do
         let(:id) { create(:character).id }

--- a/backend/spec/requests/v1/characters_spec.rb
+++ b/backend/spec/requests/v1/characters_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe 'V1::Characters' do
     get 'Retrieves a character' do
       tags 'characters'
       description 'Retrieves a specific character by id, use "random" to get a random character.'
-      operationId 'getcharacter'
+      operationId 'getCharacter'
       produces 'application/vnd.api+json'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the character. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/character_id'
 
       response '200', 'A single character' do
         let(:id) { create(:character).id }

--- a/backend/spec/requests/v1/movies_spec.rb
+++ b/backend/spec/requests/v1/movies_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe 'V1::Movies' do
     get 'Retrieves a movie' do
       tags 'movies'
       description 'Retrieves a specific movie by id, use "random" to get a random movie.'
-      operationId 'getmovie'
+      operationId 'getMovie'
       produces 'application/vnd.api+json'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the movie. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/movie_id'
 
       response '200', 'A single movie' do
         let(:id) { create(:movie).id }

--- a/backend/spec/requests/v1/movies_spec.rb
+++ b/backend/spec/requests/v1/movies_spec.rb
@@ -38,7 +38,16 @@ RSpec.describe 'V1::Movies' do
       description 'Retrieves a specific movie by id, use "random" to get a random movie.'
       operationId 'getMovie'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/movie_id'
+      parameter name: 'id',
+                description: "The identifier of the movie. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single movie' do
         let(:id) { create(:movie).id }

--- a/backend/spec/requests/v1/potions_spec.rb
+++ b/backend/spec/requests/v1/potions_spec.rb
@@ -38,7 +38,16 @@ RSpec.describe 'V1::Potions' do
       description 'Retrieves a specific potion by id, use "random" to get a random potion.'
       operationId 'getPotion'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/potion_id'
+      parameter name: 'id',
+                description: "The identifier of the potion. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single potion' do
         let(:id) { create(:potion).id }

--- a/backend/spec/requests/v1/potions_spec.rb
+++ b/backend/spec/requests/v1/potions_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe 'V1::Potions' do
     get 'Retrieves a potion' do
       tags 'potions'
       description 'Retrieves a specific potion by id, use "random" to get a random potion.'
-      operationId 'getpotion'
+      operationId 'getPotion'
       produces 'application/vnd.api+json'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the potion. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/potion_id'
 
       response '200', 'A single potion' do
         let(:id) { create(:potion).id }

--- a/backend/spec/requests/v1/spells_spec.rb
+++ b/backend/spec/requests/v1/spells_spec.rb
@@ -38,7 +38,16 @@ RSpec.describe 'V1::Spells' do
       description 'Retrieves a specific spell by id, use "random" to get a random spell.'
       operationId 'getSpell'
       produces 'application/vnd.api+json'
-      parameter '$ref': '#/components/parameters/spell_id'
+      parameter name: 'id',
+                description: "The identifier of the spell. Must be a valid UUID v4 or slug.",
+                in: :path,
+                required: true,
+                schema: {
+                  oneOf: [
+                    { '$ref' => '#/components/schemas/uuid_path' },
+                    { '$ref' => '#/components/schemas/slug_path' }
+                  ]
+                }
 
       response '200', 'A single spell' do
         let(:id) { create(:spell).id }

--- a/backend/spec/requests/v1/spells_spec.rb
+++ b/backend/spec/requests/v1/spells_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe 'V1::Spells' do
     get 'Retrieves a spell' do
       tags 'spells'
       description 'Retrieves a specific spell by id, use "random" to get a random spell.'
-      operationId 'getspell'
+      operationId 'getSpell'
       produces 'application/vnd.api+json'
-      parameter name: :id, in: :path, required: true,
-                description: "The unique identifier of the spell. Must be a valid UUID v4 or slug.",
-                schema: { '$ref' => '#components/schemas/id_path' }
+      parameter '$ref': '#/components/parameters/spell_id'
 
       response '200', 'A single spell' do
         let(:id) { create(:spell).id }

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -112,6 +112,90 @@ RSpec.configure do |config|
               default: 1
             }
           },
+          book_id: {
+            name: 'id',
+            description: 'The identifier of the book. Must be a valid UUID v4 or slug.',
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          book_chapter_id: {
+            name: 'book_id',
+            description: "The identifier of the book. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          chapter_id: {
+            name: 'id',
+            description: "The identifier of the book's chapter. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          character_id: {
+            name: 'id',
+            description: "The identifier of the character. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          movie_id: {
+            name: 'id',
+            description: "The identifier of the movie. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          potion_id: {
+            name: 'id',
+            description: "The identifier of the potion. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
+          spell_id: {
+            name: 'id',
+            description: "The identifier of the spell. Must be a valid UUID v4 or slug.",
+            in: :path,
+            required: true,
+            schema: {
+              oneOf: [
+                { '$ref' => '#/components/schemas/uuid_path' },
+                { '$ref' => '#/components/schemas/slug_path' }
+              ]
+            }
+          },
           sort_books: {
             name: :sort,
             description: 'Sort books by the given field. If prefixed with "-" sort is descending.',
@@ -282,51 +366,6 @@ RSpec.configure do |config|
           }
         },
         schemas: {
-          json_api_schema: {
-            title: 'JSON:API Schema',
-            description: 'This is a schema for reponses in the [JSON:API](https://jsonapi.org) format.',
-            oneOf: [
-              { '$ref' => '#/components/schemas/failure' },
-              { '$ref' => '#/components/schemas/info' },
-              { '$ref' => '#/components/schemas/success' }
-            ]
-          },
-          failure: {
-            type: :object,
-            required: %w[errors],
-            properties: {
-              errors: {
-                type: :array,
-                items: { '$ref' => '#/components/schemas/error' },
-                uniqueItems: true
-              }
-            },
-            additionalProperties: false
-          },
-          info: {
-            type: :object,
-            required: %w[meta],
-            properties: {
-              meta: { '$ref' => '#/components/schemas/meta' },
-              links: { '$ref' => '#/components/schemas/links' }
-            },
-            additionalProperties: false
-          },
-          success: {
-            type: :object,
-            required: %w[data],
-            properties: {
-              data: { '$ref' => '#/components/schemas/data' },
-              meta: { '$ref' => '#/components/schemas/meta' },
-              links: {
-                allOf: [
-                  { '$ref' => '#/components/schemas/links' },
-                  { '$ref' => '#/components/schemas/pagination_links'}
-                ]
-              }
-            },
-            additionalProperties: false
-          },
           meta: {
             description: 'Meta information about the response.',
             type: :object,
@@ -338,45 +377,6 @@ RSpec.configure do |config|
               copyright: "Copyright © Potter DB #{Date.today.year}",
               generated_at: DateTime.now
             }
-          },
-          data: {
-            description: 'The primary data of the response.',
-            oneOf: [
-              { '$ref' => '#/components/schemas/resource' },
-              {
-                type: :array,
-                description: 'An array of resources',
-                items: { '$ref' => '#/components/schemas/resource' },
-                uniqueItems: true
-              },
-              { type: :string, nullable: true }
-            ]
-          },
-          resource: {
-            description: 'A resource that appears in a JSON:API response.',
-            type: :object,
-            required: %w[id type],
-            properties: {
-              type: { type: :string },
-              id: { type: :string },
-              attributes: { '$ref' => '#/components/schemas/attributes' },
-              relationships: { '$ref' => '#/components/schemas/relationships' },
-              links: { '$ref' => '#/components/schemas/links' },
-              meta: { '$ref' => '#/components/schemas/meta' }
-            },
-            additionalProperties: false
-          },
-          links: {
-            type: :array,
-            description: 'Links to other resources.',
-            items: { '$ref' => '#/components/schemas/link' },
-            uniqueItems: true
-          },
-          link: {
-            description: 'A link to a resource',
-            type: :string,
-            nullable: true,
-            format: :uriReference
           },
           pagination_links: {
             type: :object,
@@ -414,105 +414,40 @@ RSpec.configure do |config|
             },
             required: %w[self]
           },
-          attributes: {
-            description: 'Attributes of a resource.',
-            type: :object,
-            not: {
-              anyOf: [
-                { required: %w[relationships] },
-                { required: %w[links] },
-                { required: %w[id] },
-                { required: %w[type] }
-              ]
-            },
-            additionalProperties: false
-          },
-
-          # relationships
-          relationships: {
-            description: 'Relationships of a resource.',
-            type: :object,
-            properties: {
-              resources: {
-                description: 'The name of the relationship resource. See [Resource Object Relationships](https://jsonapi.org/format/#document-resource-object-relationships)',
-                type: :object,
-                properties: {
-                  data: {
-                    oneOf: [
-                      { '$ref' => '#/components/schemas/relationship_to_one' },
-                      { '$ref' => '#/components/schemas/relationship_to_many' }
-                    ]
-                  }
-                }
-              }
-            },
-            additionalProperties: false
-          },
-          relationship_to_one: {
-            description: 'A relationship to a single resource.',
-            anyOf: [
-              { '$ref' => '#/components/schemas/empty_relationship' },
-              { '$ref' => '#/components/schemas/linkage_relationship' }
-            ]
-          },
-          relationship_to_many: {
-            description: 'A relationship to multiple resources.',
-            type: :array,
-            items: { '$ref' => '#/components/schemas/linkage_relationship' },
-            uniqueItems: true
-          },
-          empty_relationship: {
-            description: 'An empty relationship.',
-            type: :string,
-            nullable: true
-          },
-          linkage_relationship: {
-            description: 'A relationship to a resource.',
-            type: :object,
-            required: %w[id type],
-            properties: {
-              type: { type: :string },
-              id: {
-                description: 'The unique identifier of the resource.',
-                type: :string,
-                pattern: '^[a-zA-Z0-9](?:[-\w]*[a-zA-Z0-9])?$'
-              }
-            }
-          },
 
           # errors
-          error: {
-            type: :object,
-            properties: {
-              status: {
-                description: 'The HTTP status code applicable to this problem, expressed as a string value.',
-                type: :string
-              },
-              title: {
-                description: 'A short, human-readable summary of the problem that SHOULD NOT change from occurrence ' \
-                             'to occurrence of the problem, except for purposes of localization.',
-                type: :string
-              },
-              detail: {
-                description: 'A human-readable explanation specific to this occurrence of the problem.',
-                type: :string
-              },
-              source: {
-                type: :object,
-                properties: {
-                  pointer: {
-                    description: 'A JSON Pointer [RFC6901] to the associated entity in the request document.',
-                    type: :string
-                  },
-                  parameter: {
-                    description: 'A string indicating which URI query parameter caused the error.',
-                    type: :string
-                  }
-                }
-              }
-            },
-            additionalProperties: false
-          },
+          # error: {
+          #   type: :object,
+          #   properties: {
+          #     status: {
+          #       description: 'The HTTP status code applicable to this problem, expressed as a string value.',
+          #       type: :string
+          #     },
+          #     title: {
+          #       description: 'A short, human-readable summary of the problem that SHOULD NOT change from occurrence ' \
+          #                    'to occurrence of the problem, except for purposes of localization.',
+          #       type: :string
+          #     },
+          #     detail: {
+          #       description: 'A human-readable explanation specific to this occurrence of the problem.',
+          #       type: :string
+          #     },
+          #     source: {
+          #       type: :object,
+          #       properties: {
+          #         pointer: {
+          #           description: 'A JSON Pointer [RFC6901] to the associated entity in the request document.',
+          #           type: :string
+          #         },
+          #         parameter: {
+          #           description: 'A string indicating which URI query parameter caused the error.',
+          #           type: :string
+          #         }
+          #       }
+          #     }
+          #   },
+          #   additionalProperties: false
+          # },
           not_found: {
             type: :object,
             properties: {
@@ -533,26 +468,26 @@ RSpec.configure do |config|
               ]
             }
           },
-          internal_server_error: {
-            type: :object,
-            properties: {
-              errors: {
-                type: :array,
-                items: {
-                  type: :object,
-                  properties: {
-                    status: { type: :string, enum: ['500'] },
-                    title: { type: :string, example: "Internal Server Error" }
-                  }
-                }
-              }
-            },
-            example: {
-              errors: [
-                { title: 'Internal server error', status: '500' }
-              ]
-            }
-          },
+          # internal_server_error: {
+          #   type: :object,
+          #   properties: {
+          #     errors: {
+          #       type: :array,
+          #       items: {
+          #         type: :object,
+          #         properties: {
+          #           status: { type: :string, enum: ['500'] },
+          #           title: { type: :string, example: "Internal Server Error" }
+          #         }
+          #       }
+          #     }
+          #   },
+          #   example: {
+          #     errors: [
+          #       { title: 'Internal server error', status: '500' }
+          #     ]
+          #   }
+          # },
 
           # others
           success_without_data: {
@@ -564,10 +499,15 @@ RSpec.configure do |config|
 
             }
           },
-          id_path: {
+          uuid_path: {
+            type: :string,
+            format: :uuid,
+            example: 'c1637a49-3cc8-4285-93a1-28e6579f1f20'
+          },
+          slug_path: {
             type: :string,
             pattern: '^[a-zA-Z0-9](?:[-\w]*[a-zA-Z0-9])?$',
-            example: 'c1637a49-3cc8-4285-93a1-28e6579f1f20'
+            example: 'harry-potter-and-the-philosopher-s-stone'
           },
 
           # resource relationships
@@ -575,7 +515,7 @@ RSpec.configure do |config|
             type: :array,
             uniqueItems: true,
             items: { '$ref' => '#/components/schemas/to_one_chapter_relationship' },
-            example: { id: 'c1637a49-3cc8-4285-93a1-28e6579f1f20', type: :chapter }
+            example: [{ id: 'c1637a49-3cc8-4285-93a1-28e6579f1f20', type: :chapter }]
           },
           to_one_chapter_relationship: {
             type: :object,
@@ -646,7 +586,7 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri,
+                    pattern: "/v1/books/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
                     example: "/v1/books/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }
@@ -691,9 +631,9 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri,
+                    pattern: "/v1/books/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/chapters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
                     example:
-                      "v1/books/7f8d9b7c-5a7c-4f7c-9d5a-1d8e6f7a8b9d/chapters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
+                      "/v1/books/7f8d9b7c-5a7c-4f7c-9d5a-1d8e6f7a8b9d/chapters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }
               }
@@ -748,7 +688,7 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri,
+                    pattern: "/v1/characters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
                     example: "/v1/characters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }
@@ -797,7 +737,7 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri,
+                    pattern: "/v1/movies/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
                     example: "/v1/movies/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }
@@ -839,7 +779,8 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri
+                    pattern: "/v1/potions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                    example: "/v1/potions/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }
               }
@@ -878,7 +819,7 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
-                    format: :uri,
+                    pattern: "/v1/spells/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
                     example: "/v1/spells/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -91,7 +91,7 @@ RSpec.configure do |config|
         parameters: {
           page_size: {
             name: 'page[size]',
-            description: 'The number of returned results per page. (Between 1 and 100)',
+            description: 'The number of returned results per page (between 1 and 100).',
             in: :query,
             required: false,
             schema: {
@@ -110,90 +110,6 @@ RSpec.configure do |config|
               type: :integer,
               minimum: 1,
               default: 1
-            }
-          },
-          book_id: {
-            name: 'id',
-            description: 'The identifier of the book. Must be a valid UUID v4 or slug.',
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          book_chapter_id: {
-            name: 'book_id',
-            description: "The identifier of the book. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          chapter_id: {
-            name: 'id',
-            description: "The identifier of the book's chapter. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          character_id: {
-            name: 'id',
-            description: "The identifier of the character. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          movie_id: {
-            name: 'id',
-            description: "The identifier of the movie. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          potion_id: {
-            name: 'id',
-            description: "The identifier of the potion. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
-            }
-          },
-          spell_id: {
-            name: 'id',
-            description: "The identifier of the spell. Must be a valid UUID v4 or slug.",
-            in: :path,
-            required: true,
-            schema: {
-              oneOf: [
-                { '$ref' => '#/components/schemas/uuid_path' },
-                { '$ref' => '#/components/schemas/slug_path' }
-              ]
             }
           },
           sort_books: {
@@ -374,7 +290,7 @@ RSpec.configure do |config|
               generated_at: { type: :string, format: :date_time }
             },
             example: {
-              copyright: "Copyright © Potter DB #{Date.today.year}",
+              copyright: "Copyright © Potter DB #{Time.zone.today.year}",
               generated_at: DateTime.now
             }
           },
@@ -415,39 +331,6 @@ RSpec.configure do |config|
             required: %w[self]
           },
 
-          # errors
-          # error: {
-          #   type: :object,
-          #   properties: {
-          #     status: {
-          #       description: 'The HTTP status code applicable to this problem, expressed as a string value.',
-          #       type: :string
-          #     },
-          #     title: {
-          #       description: 'A short, human-readable summary of the problem that SHOULD NOT change from occurrence ' \
-          #                    'to occurrence of the problem, except for purposes of localization.',
-          #       type: :string
-          #     },
-          #     detail: {
-          #       description: 'A human-readable explanation specific to this occurrence of the problem.',
-          #       type: :string
-          #     },
-          #     source: {
-          #       type: :object,
-          #       properties: {
-          #         pointer: {
-          #           description: 'A JSON Pointer [RFC6901] to the associated entity in the request document.',
-          #           type: :string
-          #         },
-          #         parameter: {
-          #           description: 'A string indicating which URI query parameter caused the error.',
-          #           type: :string
-          #         }
-          #       }
-          #     }
-          #   },
-          #   additionalProperties: false
-          # },
           not_found: {
             type: :object,
             properties: {
@@ -468,26 +351,6 @@ RSpec.configure do |config|
               ]
             }
           },
-          # internal_server_error: {
-          #   type: :object,
-          #   properties: {
-          #     errors: {
-          #       type: :array,
-          #       items: {
-          #         type: :object,
-          #         properties: {
-          #           status: { type: :string, enum: ['500'] },
-          #           title: { type: :string, example: "Internal Server Error" }
-          #         }
-          #       }
-          #     }
-          #   },
-          #   example: {
-          #     errors: [
-          #       { title: 'Internal server error', status: '500' }
-          #     ]
-          #   }
-          # },
 
           # others
           success_without_data: {
@@ -631,7 +494,9 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
+                    # rubocop:disable Layout/LineLength
                     pattern: "/v1/books/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/chapters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                    # rubocop:enable Layout/LineLength
                     example:
                       "/v1/books/7f8d9b7c-5a7c-4f7c-9d5a-1d8e6f7a8b9d/chapters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
@@ -688,7 +553,9 @@ RSpec.configure do |config|
                 properties: {
                   self: {
                     type: :string,
+                    # rubocop:disable Layout/LineLength
                     pattern: "/v1/characters/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                    # rubocop:enable Layout/LineLength
                     example: "/v1/characters/c1637a49-3cc8-4285-93a1-28e6579f1f20"
                   }
                 }


### PR DESCRIPTION
<!--
Thank you for opening this pull request! Your help is much appreciated.
Please provide a short description of your changes and make sure to follow the contributing guidelines.
-->

## Summary

This adds linters for OpenAPI Specification and Rubocop. Also applies suggested linting hints. Adds github workflows to execute when making a pr / merge to master. 

## Related Issues

<!--
Please link related issues here using the following syntax:
`Fixes #<issue number>`
-->

## Checklist

- [x] This pull request has a meaningful title and description.
- [x] I have read and followed the [Contributing guidelines](https://github.com/danielschuster-muc/potter-db/blob/master/CONTRIBUTING.md).
- [x] My code follows the conventions and coding style of this project.
- [x] All tests pass and I have added tests for my changes <!-- if applicable -->
- [x] I have updated necessary documentation <!-- if applicable -->

# Screenshots (if applicable)

<!-- If applicable, please add screenshots or animated GIFs to help us understand your changes visually. -->

## Additional information

<!-- Add any additional information that may be relevant to this pull request. -->
