### PR TITLE
Documentation translated in Filipino/Tagalog

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -13,7 +13,7 @@ const withNextra = nextra({
 export default withNextra({
   reactStrictMode: true,
   i18n: {
-    locales: ['en', 'fr'],
+    locales: ['en', 'fr', 'tl'],
     defaultLocale: "en",
     localeDetection: false,
   },

--- a/docs/pages/_meta.tl.json
+++ b/docs/pages/_meta.tl.json
@@ -1,0 +1,24 @@
+{
+  "index": "Introduction",
+  "getting-started": "Nagsisimula",
+  "apis": "APIs",
+  "resources": "Resources",
+  "homepage": {
+    "title": "Potter DB",
+    "type": "page",
+    "href": "https://potterdb.com",
+    "newWindow": true
+  },
+  "status": {
+    "title": "Katayuan",
+    "type": "page",
+    "href": "https://status.potterdb.com",
+    "newWindow": true
+  },
+  "contact": {
+    "title": "Makipag-ugnayan sa amin",
+    "type": "page",
+    "href": "https://github.com/danielschuster-muc/potter-db/issues",
+    "newWindow": true
+  }
+}

--- a/docs/pages/apis/_meta.tl.json
+++ b/docs/pages/apis/_meta.tl.json
@@ -1,0 +1,4 @@
+{
+  "rest": "REST",
+  "graphql": "GraphQL"
+}

--- a/docs/pages/apis/graphql.tl.mdx
+++ b/docs/pages/apis/graphql.tl.mdx
@@ -1,0 +1,46 @@
+import { Callout } from "nextra-theme-docs";
+
+<Callout type="warning" emoji="⚠️">
+  Ang GraphQL API ay kasalukuyang gumagana at ang ilang mga tampok tulad ng pag-filter at pag-uuri ay kasalukuyang **hindi** pa ipinapatupad! Ang mga pagbabago sa API ay inaasahang mangyayari.
+</Callout>
+
+# GraphQL API
+Ang aming GraphQL API ay nagbibigay ng nababaluktot at mahusay na paraan upang makipag-ugnayan sa Potter DB. Ipakikilala sa iyo ng seksyong ito ang mga pangunahing aspeto ng aming GraphQL API at kung paano gamitin ang mga kakayahan nito.
+
+## GraphQL Endpoint
+Upang gumawa ng mga query at mutations sa GraphQL, magpadala ng mga kahilingan sa `POST` endpoint ng GraphQL (`/graphql`) kasama ang iyong mga query at variable sa body ng kahilingan. Inaasahan ng API na ang nilalaman ng kahilingan ay nasa JSON na format.
+
+## Data ng Pagtatanong
+Binibigyang-daan ka ng GraphQL na humiling ng tumpak na data na kailangan mo. Upang bumuo ng isang query, tukuyin ang mga patlang na gusto mong kunin at ang kanilang mga kaugnayan. Halimbawa:
+
+```graphql
+{
+  books(first: 3) {
+    totalCount
+    pageInfo {
+      hasNextPage
+    }
+    edges {
+      node {
+        title
+        releaseDate
+        chapters {
+          edges {
+            node {
+              title
+              slug
+            }
+          }
+        }
+      }
+    }
+  }
+  character(slug: "harry-potter") {
+    name
+  }
+}
+```
+Sa query na ito, hinihiling namin ang `title` at `releaseDate` ng unang tatlong aklat, pati na rin ang `title` at `slug` ng lahat ng chapters ng bawat libro. Bukod pa rito, hinihiling namin ang `name` ng tauhan na may slug na `harry-potter`.
+
+## Schema
+Upang makakuha ng pangkalahatang-ideya ng schema ng GraphQL API, tingnan ang aming [GraphQL Schema](https://github.com/danielschuster-muc/potter-db/blob/master/backend/app/graphql/schema.json).

--- a/docs/pages/apis/rest.tl.mdx
+++ b/docs/pages/apis/rest.tl.mdx
@@ -1,0 +1,159 @@
+# REST API
+Ang aming RESTful API ay nagbibigay ng isang tuwirang paraan upang makipag-ugnayan sa Potter DB, na sumusunod sa detalye ng JSON:API at OAS. Sa seksyong ito, tatalakayin namin ang mga pangunahing aspeto ng paggamit ng REST API, kabilang ang mga magagamit na endpoint at kung paano i-format ang iyong mga kahilingan at tugon.
+
+## Magagamit na mga Endpoints
+
+Upang ma-access ang data mula sa REST API kailangan mong gumawa ng hiling na `GET` sa isa sa mga sumusunod na endpoint:
+
+<details>
+<summary>I-expand para makita ang lahat ng endpoint</summary>
+
+**Mga Aklat**
+- `/v1/books`: Kunin ang listahan ng mga aklat.
+- `/v1/books/{id}`: Kunin ang isang libro sa pamamagitan ng ID nito.
+- `/v1/books/{book_id}/chapters`: Kunin ang isang listahan ng mga kabanata para sa isang partikular na aklat.
+- `/v1/books/{book_id}/chapters/{id}`: Kunin ang isang kabanata para sa isang partikular na aklat sa pamamagitan ng ID nito.
+
+**Mga Tauhan**
+- `/v1/characters`: Kunin ang listahan ng mga tauhan.
+- `/v1/characters/{id}`: Kunin ang isang tauhan sa pamamagitan ng ID nito.
+
+**Mga Pelikula**
+- `/v1/movies`: Kunin ang listahan ng mga pelikula.
+- `/v1/movies/{id}`: Kunin ang isang pelikula sa pamamagitan ng ID nito.
+
+**Mga Gayuma**
+- `/v1/potions`: Kunin ang listahan ng mga gayuma.
+- `/v1/potions/{id}`: Kunin ang isang gayuma sa pamamagitan ng ID nito.
+
+**Mga Orasyon**
+- `/v1/spells`: Kunin ang isang listahan ng mga orasyon.
+- `/v1/spells/{id}`: Kunin ang isang orasyon sa pamamagitan ng ID nito.
+
+Dapat ibigay ang mga ID bilang mga UUID o slug.
+
+</details>
+
+## OpenAPI Specification (OAS)
+
+Upang gawing mas madali ang pagsasama, nagbibigay kami ng isang [OpenAPI Specification](https://openapis.org) na dokumentong naglalarawan sa mga endpoint ng API, mga modelo ng data at mga schema ng kahilingan/tugon.
+Ang API ay umaayon sa bersyon 3.0.3 ng detalye ng OAS.
+Mahahanap mo ang aming kasalukuyang dokumento ng OAS [dito](https://api.potterdb.com/v1/openapi.json).
+
+## JSON:API Format
+
+Ang aming REST API ay sumusunod sa [JSON:API specification](https://jsonapi.org/), na nagbibigay ng pare-parehong paraan upang buuin ang mga kahilingan at tugon ng API. Narito ang isang pangkalahatang-ideya ng mga pangunahing tampok ng JSON:API sa konteksto ng aming API:
+
+- **Resource Objects**: Ang bawat mapagkukunan ay kinakatawan bilang isang bagay na may `type`, `id` at `attributes`.
+- **Relationships**: Ang mga mapagkukunan ay maaaring nauugnay sa iba pang mga mapagkukunan, halimbawa ang isang `book` na mapagkukunan ay nauugnay sa mga mapagkukunan ng `chapter` at vice versa.
+- **Pagination**: Kapag ang isang tugon ay naglalaman ng isang malaking bilang ng mga mapagkukunan, ang tugon ay mahahati sa ilang pahina. Tingnan ang [Pagination](#pagination) para sa mas maraming impormasyon.
+- **Errors**: Ang mga error ay ibinabalik gamit ang mga standardized na istruktura, na ginagawang madali ang paghawak at pag-troubleshoot ng mga isyu.
+
+## Paano gumawa ng mga Kahilingan
+
+Upang humiling sa REST API, kailangan mong gumawa ng hiling na `GET` sa isa sa aming mga available na endpoint.
+Narito ang isang pangunahing halimbawa kung paano kunin ang isang listahan ng mga character gamit ang `/characters` endpoint:
+
+```http
+GET https://api.potterdb.com/v1/characters
+```
+
+Mangyaring sumangguni sa dokumento ng Pagtutukoy ng OpenAPI para sa detalyadong impormasyon.
+
+## Pagination
+
+Ang mga tugon na may malaking bilang ng mga mapagkukunan ay ilalagay sa pahina. Ang tugon ay magsasama ng object na `links` na may mga link na `first`, `last`, `prev` at `next` sa una, huli, nakaraan at susunod na pahina ng mga resulta ayon sa pagkakabanggit.
+
+Upang baguhin ang dami ng mga mapagkukunan sa bawat pahina, maaari mong gamitin ang `page[size]` na query parameter (ang pinakahigit na size ay 100):
+
+```http
+GET https://api.potterdb.com/v1/characters?page[size]=25
+```
+
+Upang baguhin ang kasalukuyang pahina, maaari mong gamitin ang `page[number]` na query parameter:
+
+```http
+GET https://api.potterdb.com/v1/characters?page[number]=2
+```
+
+## Ransack
+
+Sinusuportahan ng aming REST API ang advanced na pag-filter at pag-uuri gamit ang [Ransack](https://activerecord-hackery.github.io/ransack/).
+
+### Pagpi-filter
+
+Maaari mong i-filter ang mga mapagkukunan sa pamamagitan ng pagdaragdag ng isang `filter` na query parameter sa iyong kahilingan. Halimbawa, upang i-filter ang mga character ayon sa pangalan, maaari mong gamitin ang `name_cont` na panaguri:
+
+```http
+GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
+```
+
+Ibabalik nito ang lahat ng tauhan na may pangalang "Weasley".
+
+<details>
+  <summary>I-expand para makita ang lahat ng magagamit na panaguri ng filter</summary>
+  - `eq`: katumbas 
+  - `eq_any`: katumbas ng kahit ano
+  - `eq_all`: katumbas lahat
+  - `not_eq`: hindi katumbas
+  - `not_eq_any`: hindi katumbas ng kahit ano
+  - `not_eq_all`: hindi katumbas lahat 
+  - `matches`: tugma 
+  - `matches_any`: tugma ng kahit ano
+  - `matches_all`: tugma lahat
+  - `does_not_match`: hindi tugma
+  - `does_not_match_any`: hindi tugma ng kahit ano
+  - `does_not_match_all`: hindi tugma lahat
+  - `lt`: mas mababa sa
+  - `lt_any`: mas mababa sa kahit ano
+  - `lt_all`: mas mababa sa lahat
+  - `lteq`: mas mababa sa o katumbas
+  - `lteq_any`: mas mababa sa  o katumbas ng kahit ano
+  - `lteq_all`: mas mababa o katumbas lahat
+  - `gt`: mahigit sa
+  - `gt_any`: mahigit sa kahit ano 
+  - `gt_all`: mahigit sa lahat
+  - `gteq`: mahigit sa o katumbas sa
+  - `gteq_any`: mahigit sa o katumbas sa kahit ano 
+  - `gteq_all`: mahigit sa o katumbas sa lahat
+  - `in`: sa 
+  - `in_any`: sa kahit ano
+  - `in_all`: sa lahat
+  - `not_in`: hindi sa
+  - `not_in_any`: hindi sa kahit ano
+  - `not_in_all`: hindi sa lahat
+  - `cont`: naglalaman ng 
+  - `cont_any`: naglalaman ng kahit ano
+  - `cont_all`: naglalaman ng lahat
+  - `not_cont`: hindi naglalaman ng 
+  - `not_cont_any`: hindi naglalaman ng kahit ano
+  - `not_cont_all`: hindi naglalaman ng lahat
+  - `start`: nagsisimula sa
+  - `start_any`: nagsisimula sa anuman
+  - `start_all`: nagsisimula sa lahat
+  - `not_start`: hindi nagsisimula sa
+  - `not_start_any`: hindi nagsisimula sa anuman
+  - `not_start_all`: hindi nagsisimula sa lahat
+  - `end`: nagtatapos sa
+  - `end_any`: nagtatapos sa anuman
+  - `end_all`: nagtatapos sa lahat
+  - `not_end`: hindi nagtatapos sa
+  - `not_end_any`: hindi nagtatapos sa anuman
+  - `not_end_all`: hindi nagtatapos sa lahat
+  - `'true'`: ay totoo 
+  - `'false'`: ay huwad
+  - `present`: ay naroroon
+  - `blank`: ay blanko
+  - `'null'`: ay null 
+  - `not_null`: ay hindi null
+</details>
+
+### Pakasunod-sunod
+
+Maaari mong ayusin ang mga mapagkukunan sa pamamagitan ng pagdaragdag ng isang `sort` na query parameter sa iyong kahilingan. Halimbawa, upang pagbukud-bukurin ang mga tauhan ayon sa pangalan, maaari mong gamitin ang `name` na katangian (magtungo sa [Resources](#resources) para makita ang lahat ng magagamit na katangian):
+
+```http
+GET https://api.potterdb.com/v1/characters?sort=name
+```
+
+Gamitin ang `-` na unlapi upang ayusin sa pababang pagkakasunud-sunod.

--- a/docs/pages/getting-started.tl.mdx
+++ b/docs/pages/getting-started.tl.mdx
@@ -1,0 +1,44 @@
+import { Bleed } from 'nextra-theme-docs'
+
+# REST laban sa GraphQL
+Ang Potter DB: API ay may dalawang paraan upang maibahagi ang mga mahiwagang datos: **REST** and **GraphQL**. Pumili ng paraan na pinaka  angkop sa iyong pangangailangan at estilo ng pagbuo.
+- **REST**: Kung nais mo ng mas tuwid na paraan, diskarte na nakasentro sa mga datos, ang REST endpoints ang pinaka angkop gamitin. Maaari kang gumawa ng mga HTTP requests sa mga tiyak na URLs upang makuha ang data.
+- **GraphQL**: Para sa mas madaling maangkop at mas tumpak na mga kahilingan ukol sa data, pinapayagan ka ng GraphQL na humiling nang eksakto kung ano ang kailangan mo at wala nang iba pa. Buuin ang iyong mga query para kumuha ng data na may pinong kontrol.
+
+## Mga Teknikal na detalye
+{
+<table>
+  <thead>
+    <tr>
+      <th>Ano</th>
+      <th>Paglalarawan</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Pagpapatunay</td>
+      <td>Libreng gamitin, <b>walang pagpapatunay</b> na kailangan</td>
+    </tr>
+    <tr>
+      <td>Base URL</td>
+      <td>
+        https://api.potterdb.com/
+      </td>
+    </tr>
+    <tr>
+      <td>Kasalukuyang bersyon</td>
+      <td>v1</td>
+    </tr>
+  </tbody>
+</table>
+}
+
+## Paglimita sa rate
+Upang mapanatili ang kalidad and mapigilan ang malisyosong paggamit ng Potter DB: API mayroong limitasyong ip-based ng **900 na kahilingan kada oras** (15 kahilingan / minuto). Kung naabot mo ang limitasyong ito, ikaw ay makakatanggap ng a `429 To Many Requests` (masyadong maraming kahilingan).
+Pakitandaan na ang mga limitasyon sa rate na ito ay maaaring magbago, kaya mahalagang suriin ang pinakabagong impormasyon sa limitasyon ng rate sa dokumentasyon o sa pamamagitan ng mga tugon sa API.
+
+<br />
+
+__Ngayong mayroon ka nang mga pangunahing kaalaman, sumisid tayo sa dokumentasyon ng API upang tuklasin ang mga available na endpoint at simulan ang paggawa ng iyong mga mahiwagang query.
+Sumangguni sa mga seksyon ng dokumentasyon para sa [REST](/apis/rest) at [GraphQL](apis/graphql) para sa detalyadong impormasyon sa kung paano epektibong gamitin ang API.
+Upang makakuha ng pangkalahatang-ideya ng lahat ng magagamit na mapagkukunan, tingnan ang [Pangkalahatang-ideya ng mga Mapagkukunan](/resources)._

--- a/docs/pages/index.tl.mdx
+++ b/docs/pages/index.tl.mdx
@@ -1,0 +1,89 @@
+import { useSSG } from "nextra/ssg";
+
+import { Callout } from "nextra-theme-docs";
+
+import graphqlFetcher from "../lib/fetchers/graphqlFetcher";
+
+export const getStaticProps = async ({ params }) => {
+  const query = `
+    {
+      books {
+        totalCount
+      }
+      characters {
+        totalCount
+      }
+      spells {
+        totalCount
+      }
+      potions {
+        totalCount
+      }
+      movies {
+        totalCount
+      }
+    }
+  `;
+  const result = await graphqlFetcher(query);
+  const mapped_result = result?.data;
+  let hash = {};
+  for (let k in mapped_result) {
+    hash["total_" + k] = mapped_result[k]?.totalCount;
+  }
+  return {
+    props: {
+      ssg: hash,
+    },
+  };
+};
+
+export const Stats = () => {
+  const {
+    total_books,
+    total_characters,
+    total_spells,
+    total_potions,
+    total_movies,
+  } = useSSG();
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <td>Mga Aklat</td>
+          <td>{total_books}</td>
+        </tr>
+        <tr>
+          <td>Mga Tauhan</td>
+          <td>{total_characters}</td>
+        </tr>
+        <tr>
+          <td>Mga Pelikula</td>
+          <td>{total_movies}</td>
+        </tr>
+        <tr>
+          <td>Mga Gayuma</td>
+          <td>{total_potions}</td>
+        </tr>
+        <tr>
+          <td>Mga Orasyon</td>
+          <td>{total_spells}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+# Panimula
+
+Maligayang pagdating sa dokumentasyon ng **Potter DB: API**!
+Sumisid sa mahiwagang mundo ng Harry Potter na may paraan sa pagkuha ng datos sa mga tauhan, aklat, orasyon, at higit pa.
+Isa ka mang tagabuo na gumagawa ng isang aplikasyon na halaw sa tema ng Potter o isang mausisa na tagahanga lang, magiging gabay sa iyo ang dokumentasyong ito sa mga nakatagong lihim ng aming API.
+
+## Ano ang Potter DB: API?
+Ang Potter DB: API ay isang interface na nakabatay sa REST at GraphQL para sa malawak imbakan ng datos mula sa mahiwagang mundo ng Harry Potter. Kami ang bahala sa mga datos, nang sa gayon maituon ninyo ang inyong panahon sa pagbuo ng inyong app. Sa pamamagitan ng API na ito, maaari ninyong gawin ang sumusunod :
+- Magtamo ng detalyadong impormasyon tungkol sa inyong mga minamahal na `mga tauhan`, kabilang ang kanilang their pansariling kasaysayan, kabilang na tahanan, and marami pang iba.
+- Magsaliksik ng kumprehensibong talaan ng mga of `mga orasyon` at `mga gayuma` na ginagamit sa mahiwagang mundo.
+- Magsiyasat ng  masusing detalye tungkol sa `mga aklat` at `mga pelikula` sa sandaigdigan ng Harry Potter.
+
+## Estatistika
+<Stats />

--- a/docs/pages/resources.tl.mdx
+++ b/docs/pages/resources.tl.mdx
@@ -1,0 +1,30 @@
+import { Card, Cards } from 'nextra/components'
+
+# Resources Overview
+
+<Cards>
+  <Card
+    title="Mga Aklat"
+    href="/resources/books"
+  />
+  <Card
+    title="Mga Kabanata"
+    href="/resources/chapters"
+  />
+  <Card
+    title="Mga Tauhan"
+    href="/resources/characters"
+  />
+  <Card
+    title="Mga Pelikula"
+    href="/resources/movies"
+  />
+  <Card
+    title="Mga Gayuma"
+    href="/resources/potions"
+  />
+  <Card
+    title="Mga Orasyon"
+    href="/resources/spells"
+  />
+</Cards>

--- a/docs/pages/resources/_meta.tl.json
+++ b/docs/pages/resources/_meta.tl.json
@@ -1,0 +1,8 @@
+{
+  "books": "Mga Aklat",
+  "chapters": "Mga Kabanata",
+  "characters": "Mga Tauhan",
+  "movies": "Mga Pelikula",
+  "potions": "Mga Gayuma",
+  "spells": "Mga Orasyon"
+}

--- a/docs/pages/resources/books.tl.mdx
+++ b/docs/pages/resources/books.tl.mdx
@@ -1,0 +1,81 @@
+# Mga Aklat
+Ang mapagkukunang ito ay nagbibigay ng impormasyon tungkol sa mga aklat mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      {
+        name: "author",
+        type: "mga titik",
+        description: "Ang manunulat ng aklat na ito",
+        filterable: true,
+      },
+      {
+        name: "cover",
+        type: "mga titik",
+        description: "Ang url sa pabalat ng aklat na ito.",
+        filterable: false,
+      },
+      {
+        name: "dedication",
+        type: "mga titik",
+        description: "Ang dedikasyon ng aklat na ito.",
+        filterable: true,
+      },
+      {
+        name: "pages",
+        type: "numero",
+        description: "Ang bilang ng pahina ng aklat na ito.",
+        filterable: true,
+      },
+      {
+        name: "release_date",
+        type: "petsa",
+        description: "Ang petsa kung kailan nailathala ang aklat na ito.",
+        filterable: true,
+      },
+      {
+        name: "summary",
+        type: "mga titik",
+        description: "Ang buod ng aklat na ito.",
+        filterable: true,
+      },
+      {
+        name: "slug",
+        type: "mga titik",
+        description: "Isang slug upang kilalanin ang aklat na ito.",
+        filterable: false,
+      },
+      {
+        name: "title",
+        type: "mga titik",
+        description: "Ang pamagat ng aklat na ito.",
+        filterable: true,
+      },
+      {
+        name: "wiki",
+        type: "mga titik",
+        description: "Isang link patungo sa Harry Potter Wiki Page ng aklat na ito.",
+        filterable: false,
+      },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? "✅" : "❌"}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+}

--- a/docs/pages/resources/chapters.tl.mdx
+++ b/docs/pages/resources/chapters.tl.mdx
@@ -1,0 +1,51 @@
+# Mga Kabanata
+Ang mapagkukunan na ito ay nagbibigay ng impormasyon tungkol sa mga tiyak na kabanata mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      {
+        name: "order",
+        type: "numero",
+        description: "Ang pagkakasunod-sunod ng kabanatang ito sa loob ng aklat.",
+        filterable: true,
+      },
+      {
+        name: "slug",
+        type: "mga titik",
+        description: "Isang slug upang kilalanin ang kabanatang ito.",
+        filterable: false,
+      },
+      {
+        name: "summary",
+        type: "mga titik",
+        description: "Ang buod ng kabanatang na ito.",
+        filterable: true,
+      },
+      {
+        name: "title",
+        type: "string",
+        description: "Ang pamagat ng kabanatang ito.",
+        filterable: true,
+      },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? "✅" : "❌"}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+}

--- a/docs/pages/resources/characters.tl.mdx
+++ b/docs/pages/resources/characters.tl.mdx
@@ -1,0 +1,53 @@
+# Mga Tauhan
+Ang mapagkukunang ito ay nagbibigay ng impormasyon tungkol sa mga tauhan mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      { name: "alias_names", type: "array", description: "Isang listahan ng mga pangalan ng mga tauhan na, kung hindi man ay ang alyas kung saan kilala sila bilang.", filterable: true },
+      { name: "animagus", type: "mga titik", description: "Ang animagus ng tauhan na ito.", filterable: true },
+      { name: "blood_status", type: "mga titik", description: "Ang katayuan ng dugo ng tauhan na ito.", filterable: true },
+      { name: "boggart", type: "mga titik", description: "Ang boggart ng tauhan na ito.", filterable: true },
+      { name: "born", type: "mga titik", description: "Ang petsa at lugar ng kapanganakan ng tauhan na ito.", filterable: true },
+      { name: "died", type: "mga titik", description: "Ang petsa at lugar ng kamatayan ng tauhan na ito.", filterable: true },
+      { name: "eye_color", type: "mga titik", description: "Ang kulay ng mata ng tauhan na ito.", filterable: true },
+      { name: "family_member", type: "array", description: "Isang listahan ng mga miyembro ng pamilya ng tauhan na ito.", filterable: true },
+      { name: "gender", type: "mga titik", description: "Ang kasarian ng tauhan na ito.", filterable: true },
+      { name: "hair_color", type: "mga titik", description: "Ang kulay ng buhok ng tauhan na ito.", filterable: true },
+      { name: "height", type: "mga titik", description: "Ang taas ng tauhan na ito gamit ang pulgada.", filterable: true },
+      { name: "house", type: "mga titik", description: "Ang kinabibilangang kabahayang hogwarts ng tauhan na ito.", filterable: true },
+      { name: "image", type: "mga titik", description: "Isang link patungo sa isang larawan ng tauhan na ito.", filterable: false },
+      { name: "jobs", type: "array", description: "Isang listahan ng mga trabahong ginawa ng tauhan na ito.", filterable: true },
+      { name: "name", type: "mga titik", description: "Ang marangal na titulo ng tauhan na ito.", filterable: true },
+      { name: "nationality", type: "mga titik", description: "Ang pagkamakabayan ng tauhan na ito.", filterable: true },
+      { name: "patronus", type: "mga titik", description: "Ang patronus ng tauhan na ito.", filterable: true },
+      { name: "romances", type: "array", description: "Isang listahan ng mga naging kasintahan ng tauhan na ito.", filterable: true },
+      { name: "skin_color", type: "mga titik", description: "Ang kulay ng balat ng tauhan na ito.", filterable: true },
+      { name: "slug", type: "mga titik", description: "Isang slug upang kilalanin ang tauhan na ito.", filterable: false },
+      { name: "species", type: "mga titik", description: "Ang uri ng tauhan na ito.", filterable: true },
+      { name: "titles", type: "array", description: "Isang listahan ng mga pangalan na naglalarawan sa posisyon o trabaho ng isang tauhan.", filterable: true },
+      { name: "wand", type: "array", description: "Isang listahan ng mga wand ng tauhan na ito.", filterable: true },
+      { name: "weight", type: "mga titik", description: "Ang bigat ng tauhan na ito gamit ang libra.", filterable: true },
+      { name: "wiki", type: "mga titik", description: "Isang link sa Harry Potter Wiki Page ng tauhan na ito.", filterable: false },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? '✅' : '❌'}</td>
+      </tr>
+    ))}
+
+  </tbody>
+</table>
+}

--- a/docs/pages/resources/movies.tl.mdx
+++ b/docs/pages/resources/movies.tl.mdx
@@ -1,0 +1,135 @@
+# Mga Pelikula
+Ang mapagkukunan na ito ay nagbibigay ng impormasyon tungkol sa mga pelikula mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      {
+        name: "box_office",
+        type: "mga titik",
+        description: "Ang kinita ng pelikulang ito sa pamamagitan ng pagbebenta ng tiket.",
+        filterable: true,
+      },
+      {
+        name: "budget",
+        type: "mga titik",
+        description: "Ang badyet ng pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "cinematographers",
+        type: "array",
+        description: "Isang listahan ng mga cinematographer sa mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "directors",
+        type: "array",
+        description: "Isang listahan ng mga taong nagdirek ng mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "distributors",
+        type: "array",
+        description: "Isang listahan ng mga taong namahagi ng mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "editors",
+        type: "array",
+        description: "Isang listahan ng mga taong nag-matnugot ng mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "music_composers",
+        type: "array",
+        description: "Isang listahan ng mga taong gumawa ng musika ng mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "poster",
+        type: "string",
+        description: "Isang link sa paskil ng pelikulang ito.",
+        filterable: false,
+      },
+      {
+        name: "producers",
+        type: "array",
+        description: "Isang listahan ng mga taong gumawa ng mga pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "rating",
+        type: "mga titik",
+        description: "Ang rekomendasyon sa edad ng pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "release_date",
+        type: "petsa",
+        description: "Ang petsa kung kailan ipinalabas ang pelikulang ito..",
+        filterable: true,
+      },
+      {
+        name: "running_time",
+        type: "mga titik",
+        description: "Ang tagal ng takbo ng pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "screenwriters",
+        type: "array",
+        description: "Isang listahan ng mga tagasulat ng senaryo sa mga pelikulang ito",
+        filterable: true,
+      },
+      {
+        name: "slug",
+        type: "mga titik",
+        description: "Isang slug upang kilalanin ang pelikulang ito.",
+        filterable: false,
+      },
+      {
+        name: "summary",
+        type: "mga titik",
+        description: "Ang buod ng pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "title",
+        type: "mga titik",
+        description: "Ang pamagat ng pelikulang ito.",
+        filterable: true,
+      },
+      {
+        name: "trailer",
+        type: "mga titik",
+        description: "Isang link sa pasilip na bidyo ng pelikulang ito.",
+        filterable: false,
+      },
+      {
+        name: "wiki",
+        type: "mga titik",
+        description: "Isang link sa Harry Potter Wiki Page ng pelikulang ito.",
+        filterable: false,
+      },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? "✅" : "❌"}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+}

--- a/docs/pages/resources/potions.tl.mdx
+++ b/docs/pages/resources/potions.tl.mdx
@@ -1,0 +1,99 @@
+# Mga Gayuma
+Ang mapagkukunang ito ay nagbibigay ng impormasyon tungkol sa mga gayuma mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      {
+        name: "characteristics",
+        type: "mga titik",
+        description: "Ang katangian ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "difficulty",
+        type: "mga titik",
+        description: "Ang antas ng hirap na itimpla ang gayumang ito",
+        filterable: true,
+      },
+      {
+        name: "effect",
+        type: "mga titik",
+        description: "Ang pangunahing epekto ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "image",
+        type: "mga titik",
+        description: "Isang link patungo sa isang larawan ng gayumang ito.",
+        filterable: false,
+      },
+      {
+        name: "inventors",
+        type: "mga titik",
+        description: "Ang mga manlilikha ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "ingredients",
+        type: "mga titik",
+        description: "Ang mga sangkap na kailangan sa paggawa ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "manufacturers",
+        type: "mga titik",
+        description: "Ang mga tagagawa ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "name",
+        type: "mga titik",
+        description: "Ang pangalan ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "side_effects",
+        type: "mga titik",
+        description: "Ang mga di nilalayong bisa ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "slug",
+        type: "mga titik",
+        description: "Isang slug upang kilalanin ang gayumang ito.",
+        filterable: false,
+      },
+      {
+        name: "time",
+        type: "mga titik",
+        description: "Ang oras na ginugol sa pagtimpla ng gayumang ito.",
+        filterable: true,
+      },
+      {
+        name: "wiki",
+        type: "mga titik",
+        description: "Isang link sa Harry Potter Wiki Page ng gayumang ito.",
+        filterable: false,
+      },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? "✅" : "❌"}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+}

--- a/docs/pages/resources/spells.tl.mdx
+++ b/docs/pages/resources/spells.tl.mdx
@@ -1,0 +1,87 @@
+# Mga Orasyon
+Ang mapagkukunan na ito ay nagbibigay ng impormasyon tungkol sa mga orasyon mula sa uniberso ng Harry Potter.
+
+## Mga Katangian
+{
+<table>
+  <thead>
+    <tr>
+      <th>Pangalan</th>
+      <th>Uri</th>
+      <th>Paglalarawan</th>
+      <th>Nai-ifilter</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      {
+        name: "category",
+        type: "mga titik",
+        description: "Ang pangkat ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "creator",
+        type: "mga titik",
+        description: "Ang manlilikha ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "effect",
+        type: "mga titik",
+        description: "Ang epekto ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "hand",
+        type: "mga titik",
+        description: "Ang galaw ng kamay ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "image",
+        type: "mga titik",
+        description: "Isang link patungo sa isang larawan ng orasyon na ito.",
+        filterable: false,
+      },
+      {
+        name: "incantation",
+        type: "mga titik",
+        description: "Ang bulong ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "light",
+        type: "mga titik",
+        description: "Ang liwanag ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "name",
+        type: "mga titik",
+        description: "Ang pangalan ng orasyon na ito.",
+        filterable: true,
+      },
+      {
+        name: "slug",
+        type: "mga titik",
+        description: "Isang slug upang kilalanin ang orasyon na ito.",
+        filterable: false,
+      },
+      {
+        name: "wiki",
+        type: "mga titik",
+        description: "Isang link sa Harry Potter Wiki Page ng orasyon na ito.",
+        filterable: false,
+      },
+    ].map((item) => (
+      <tr key={item.name}>
+        <td>{item.name}</td>
+        <td>{item.type}</td>
+        <td>{item.description}</td>
+        <td>{item.filterable == true ? "✅" : "❌"}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+}

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -19,6 +19,8 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           return "Editer cette page sur GitHub →";
+        case "tl":
+          return "I-edit ang pahinang ito sa GitHub →";
         default:
           return "Edit this page on GitHub →";
       }
@@ -31,6 +33,8 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           return "Donnez-nous votre avis →";
+        case "tl":
+          return "Bigyan kami ng katugunan →";
         default:
           return "Give us feedback →";
       }
@@ -45,6 +49,9 @@ const config: DocsThemeConfig = {
     switch (locale) {
       case "fr":
         text = "Dernière mise à jour le";
+        break;
+      case "tl":
+        text = "Huling ini-update noong";
         break;
       default:
         text = "Last updated on";
@@ -68,7 +75,7 @@ const config: DocsThemeConfig = {
       <meta name="og:title" content="Potter DB: Docs" />
     </>
   ),
-  i18n: [{ locale: "en", text: "English" },{ locale: "fr", text: "Français" }],
+  i18n: [{ locale: "en", text: "English" },{ locale: "fr", text: "Français" },{ locale: "tl", text: "Filipino/Tagalog" }],
   logo: <span>Potter DB: Docs</span>,
   project: {
     link: "https://github.com/danielschuster-muc/potter-db",
@@ -79,6 +86,8 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           return "Rechercher...";
+        case "tl":
+            return "Maghanap...";
         default:
           return "Search...";
       }
@@ -88,6 +97,8 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           return "En cours de chargement...";
+        case "tl":
+            return "Naglo-load...";
         default:
           return "Loading...";
       }
@@ -98,6 +109,9 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           text = "Aucun résultat.";
+          break;
+        case "tl":
+          text = "Walang nahanap na resulta";
           break;
         default:
           text = "No results found.";
@@ -130,6 +144,12 @@ const config: DocsThemeConfig = {
             dark: "Sombre",
             system: "Système",
           };
+        case "tl":
+          return {
+            light: "Liwanag",
+            dark: "Dilim",
+            system: "Sistema",
+          };
         default:
           return {
             light: "Light",
@@ -146,6 +166,8 @@ const config: DocsThemeConfig = {
       switch (locale) {
         case "fr":
           return "Sur cette page";
+        case "tl":
+          return "Sa pahinang ito";
         default:
           return "On this page";
       }


### PR DESCRIPTION
## Summary

Here is the translation of the documentation in Filipino/Tagalog (Philippines)

## Related Issues

It's part of the issue #738 

## Checklist

- [x] This pull request has a meaningful title and description.
- [x] I have read and followed the [Contributing guidelines](https://github.com/danielschuster-muc/potter-db/blob/master/CONTRIBUTING.md).
- [x] My code follows the conventions and coding style of this project.

## Additional information

I tried testing this but even after updating these files, the 'Filipino/Tagalog' option isn't showing up in the choices:
- [docs/theme.config.tsx](https://github.com/danielschuster-muc/potter-db/blob/master/docs/theme.config.tsx)
- [docs/next.config.js](https://github.com/danielschuster-muc/potter-db/blob/master/docs/next.config.js)

I'm not quite sure what seems to be the issue but I've finished translating the docs, so I created a PR and also to fix this.