### PR TITLE
Change filter predicate in example

### DIFF
--- a/docs/pages/apis/rest.en.mdx
+++ b/docs/pages/apis/rest.en.mdx
@@ -86,7 +86,7 @@ Our REST API supports advanced filtering and sorting using [Ransack](https://act
 You can filter resources by adding a `filter` query parameter to your request. For example, to filter characters by name, you can use the `name_cont` predicate:
 
 ```http
-GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
+GET https://api.potterdb.com/v1/characters?filter[name_cont]=Weasley
 ```
 
 This will return all characters with the name "Weasley".

--- a/docs/pages/apis/rest.es.mdx
+++ b/docs/pages/apis/rest.es.mdx
@@ -86,7 +86,7 @@ Nuestra API REST admite el filtrado y la clasificación avanzados mediante [Rans
 Puede filtrar recursos añadiendo un parámetro de consulta `filter` a su petición. Por ejemplo, para filtrar caracteres por nombre, puede utilizar el predicado `name_cont`:
 
 ```http
-GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
+GET https://api.potterdb.com/v1/characters?filter[name_cont]=Weasley
 ```
 
 Esto devolverá todos los personajes con el nombre "Weasley".

--- a/docs/pages/apis/rest.fr.mdx
+++ b/docs/pages/apis/rest.fr.mdx
@@ -86,7 +86,7 @@ Notre API REST supporte une fonctionnalité de filtre avancé et de tri en utili
 Vous pouvez filtrer une requête en ajoutant le mot-clef `filter` en paramètre de requête. Par exemple, pour filter les personnages par nom, vous utiliserez le prédicat `name_cont` :
 
 ```http
-GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
+GET https://api.potterdb.com/v1/characters?filter[name_cont]=Weasley
 ```
 
 Ceci vous retournera tous les personnages qui portent le nom "Weasley".

--- a/docs/pages/apis/rest.sk.mdx
+++ b/docs/pages/apis/rest.sk.mdx
@@ -85,7 +85,7 @@ Naše REST API podporuje pokročilé filtrovanie a zoraďovanie pomocou knižnic
 Zdroje môžete filtrovať pridaním parametru `filter` do vašej požiadavky. Ak chcete napríklad filtrovať postavy podľa mena, použite predikát `name_eq`:
 
 ```http
-GET https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley
+GET https://api.potterdb.com/v1/characters?filter[name_cont]=Weasley
 ```
 
 Táto požiadavka vráti všetky postavy s menom "Weasley".


### PR DESCRIPTION
<!--
Thank you for opening this pull request! Your help is much appreciated.
Please provide a short description of your changes and make sure to follow the contributing guidelines.
-->

## Summary

<!-- Provide a brief summary of the changes and the problem it solves. -->
While working on the documentation I tried out some of the example API requests. I noticed that `https://api.potterdb.com/v1/characters?filter[name_eq]=Weasley` doesn't return anything (I'm assuming because the character's name consists of first name and last name). 

Also the paragraph mentions `[name_cont]`. That's why I'm tweaking it slightly to use `[name_cont]` to fix this small inconsistency and to give users an example that actually returns something.

## Related Issues
n/a
<!--
Please link related issues here using the following syntax:
`Fixes #<issue number>`
-->

## Checklist

- [x] This pull request has a meaningful title and description.
- [x] I have read and followed the [Contributing guidelines](https://github.com/danielschuster-muc/potter-db/blob/master/CONTRIBUTING.md).
- [x] My code follows the conventions and coding style of this project.
- [x] All tests pass and I have added tests for my changes <!-- if applicable -->
- [x] I have updated necessary documentation <!-- if applicable -->

## Additional information

<!-- Add any additional information that may be relevant to this pull request. -->
Just curious: How would you query the characters' endpoint when using `[name_eq]`? I tried a few things but never got any results back...